### PR TITLE
move expiry from struct item to struct itemx

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ struct itemx {
   uint8_t             md[20]; /* sha1 message digest */
   uint32_t            sid;    /* owner slab id */
   uint32_t            offset; /* item offset from owner slab base */
+  rel_time_t          expiry; /* expiry in secs */
   uint64_t            cas;    /* cas */
 } __attribute__ ((__packed__));
 ```
@@ -54,9 +55,9 @@ Each index entry contains both object-specific information (key name, &c.) and d
 
 To further reduce the memory consumed by the index, we store the SHA-1 hash of the key in each index entry, instead of the key itself. The SHA-1 hash acts as the unique identifier for each object. The on-disk object format contains the complete object key and value. False positives from SHA-1 hash collisions are detected after object retrieval from the disk by comparison with the requested key. If there are collisions on the write path, new objects with the same hash key simply overwrite previous objects.
 
-The index entry (struct itemx) on a 64-bit system is 44 bytes in size. It is possible to further reduce index entry size to 28 bytes, if CAS is unsupported, MD5 hashing is used, and the next pointer is reduced to 4 bytes.
+The index entry (struct itemx) on a 64-bit system is 48 bytes in size. It is possible to further reduce index entry size to 32 bytes, if CAS is unsupported, MD5 hashing is used, and the next pointer is reduced to 4 bytes.
 
-At this point, it is instructive to consider the relative size of fatcache's index and the on-disk data. With a 44 byte index entry, an index consuming 44 MB of memory can address 1M objects. If the average object size is 1 KB, then a 44 MB index can address 1 GB of on-disk storage - a 23x memory overcommit. If the average object size is 500 bytes, then a 44 MB index can address 500 MB of SSD - a 11x memory overcommit. Index size and object size relate in this way to determine the addressable capacity of the SSD.
+At this point, it is instructive to consider the relative size of fatcache's index and the on-disk data. With a 44 byte index entry, an index consuming 48 MB of memory can address 1M objects. If the average object size is 1 KB, then a 48 MB index can address 1 GB of on-disk storage - a 23x memory overcommit. If the average object size is 500 bytes, then a 48 MB index can address 500 MB of SSD - a 11x memory overcommit. Index size and object size relate in this way to determine the addressable capacity of the SSD.
 
 ## Build
 

--- a/src/fc_item.c
+++ b/src/fc_item.c
@@ -25,18 +25,6 @@ extern struct settings settings;
 static uint64_t cas_id;
 
 /*
- * Return true if the item has expired, otherwise return false. Items
- * with expiry of 0 are considered as unexpirable.
- */
-bool
-item_expired(struct item *it)
-{
-    ASSERT(it->magic == ITEM_MAGIC);
-
-    return (it->expiry != 0 && it->expiry < time_now()) ? true : false;
-}
-
-/*
  * Return the owner slab of item it.
  */
 struct slab *
@@ -91,7 +79,6 @@ item_get(uint8_t *key, uint8_t nkey, uint8_t cid, uint32_t ndata,
     it->cid = cid;
     it->nkey = nkey;
     it->ndata = ndata;
-    it->expiry = expiry;
     it->flags = flags;
     fc_memcpy(it->md, md, sizeof(it->md));
     it->hash = hash;
@@ -100,9 +87,9 @@ item_get(uint8_t *key, uint8_t nkey, uint8_t cid, uint32_t ndata,
 
     log_debug(LOG_VERB, "get it '%.*s' at offset %"PRIu32" with cid %"PRIu8
               " expiry %u", it->nkey, item_key(it), it->offset, it->cid,
-              it->expiry);
+              expiry);
 
-    itemx_putx(it->hash, it->md, it->sid, it->offset, ++cas_id);
+    itemx_putx(it->hash, it->md, it->sid, it->offset, expiry, ++cas_id);
 
     return it;
 }

--- a/src/fc_item.h
+++ b/src/fc_item.h
@@ -28,7 +28,6 @@ struct item {
     uint8_t           unused[2];  /* unused */
     uint8_t           nkey;       /* key length */
     uint32_t          ndata;      /* date length */
-    rel_time_t        expiry;     /* expiry in secs */
     uint32_t          flags;      /* flags opaque to the server */
     uint8_t           md[20];     /* key message digest */
     uint32_t          hash;       /* key hash */

--- a/src/fc_itemx.c
+++ b/src/fc_itemx.c
@@ -33,6 +33,18 @@ static struct itemx *istart;         /* itemx memory start */
 static struct itemx *iend;           /* itemx memory end */
 
 /*
+ * Return true if the itemx has expired, otherwise return false. Itemx
+ * with expiry of 0 are considered as unexpirable.
+ */
+bool
+itemx_expired(struct itemx *itx)
+{
+    ASSERT(itx != NULL);
+
+    return (itx->expiry != 0 && itx->expiry < time_now()) ? true : false;
+}
+
+/*
  * Returns true, if there are no free item indexes, otherwise
  * return false.
  */
@@ -178,7 +190,7 @@ itemx_getx(uint32_t hash, uint8_t *md)
 
 void
 itemx_putx(uint32_t hash, uint8_t *md, uint32_t sid, uint32_t offset,
-           uint64_t cas)
+           rel_time_t expiry, uint64_t cas)
 {
     struct itemx *itx;
     struct itemx_tqh *bucket;
@@ -188,6 +200,7 @@ itemx_putx(uint32_t hash, uint8_t *md, uint32_t sid, uint32_t offset,
     itx = itemx_get();
     itx->sid = sid;
     itx->offset = offset;
+    itx->expiry = expiry;
     itx->cas = cas;
     fc_memcpy(itx->md, md, sizeof(itx->md));
 

--- a/src/fc_itemx.c
+++ b/src/fc_itemx.c
@@ -39,9 +39,17 @@ static struct itemx *iend;           /* itemx memory end */
 bool
 itemx_expired(struct itemx *itx)
 {
+    uint32_t hash;
+
     ASSERT(itx != NULL);
 
-    return (itx->expiry != 0 && itx->expiry < time_now()) ? true : false;
+    if(itx->expiry != 0 && itx->expiry < time_now()) {
+        hash = sha1_hash(itx->md);
+        itemx_removex(hash, itx->md);
+        return true;
+    } else {
+        return false;
+    }
 }
 
 /*

--- a/src/fc_itemx.h
+++ b/src/fc_itemx.h
@@ -25,6 +25,7 @@ struct itemx {
     uint8_t             md[20]; /* sha1 message digest */
     uint32_t            sid;    /* owner slab id */
     uint32_t            offset; /* item offset from owner slab base */
+    rel_time_t          expiry; /* expiry in secs */
     uint64_t            cas;    /* cas */
 } __attribute__ ((__packed__));
 
@@ -34,8 +35,9 @@ rstatus_t itemx_init(void);
 void itemx_deinit(void);
 
 bool itemx_empty(void);
+bool itemx_expired(struct itemx *itx);
 struct itemx *itemx_getx(uint32_t hash, uint8_t *md);
-void itemx_putx(uint32_t hash, uint8_t *md, uint32_t sid, uint32_t ioff, uint64_t cas);
+void itemx_putx(uint32_t hash, uint8_t *md, uint32_t sid, uint32_t ioff, rel_time_t expiry, uint64_t cas);
 bool itemx_removex(uint32_t hash, uint8_t *md);
 
 #endif


### PR DESCRIPTION
1. Move expiry to itemx, when item was expired, we didn't need to access disk again.
2. Remove expired item, when item was touched.
