### PR TITLE
MOD: setting keepalive for an new connection

### DIFF
--- a/src/fc_server.c
+++ b/src/fc_server.c
@@ -77,6 +77,12 @@ server_accept(struct context *ctx, struct conn *s)
                  strerror(errno));
     }
 
+    status = fc_set_keepalive(c->sd);
+    if (status < 0) {
+        log_warn("set tcp keepalive on c %d failed, ignored: %s", sd,
+                 strerror(errno));
+    }
+
     status = event_add_conn(ctx->ep, c);
     if (status < 0) {
         log_error("event add conn e %d c %d failed: %s", ctx->ep, sd,


### PR DESCRIPTION
Connction leak occured when we deploy Fatcache in our large production cluster. We can see lots of socket fd in /proc/<pid>/fd, in fact there is no connection from clients.

It ocurred because of the packages loss of four wave(the unstable network, lvs, firewall) when the client close the socket.

By the way, we checked the lastest Memcached and Redis source code, all of them had been set keepalive for the socket as default, and Twemproxy can be set by config file.
